### PR TITLE
Remove entity information outside of the object within a series

### DIFF
--- a/docs/developer/engines/standards/engine-output/vtn-standard.example.js
+++ b/docs/developer/engines/standards/engine-output/vtn-standard.example.js
@@ -339,10 +339,6 @@ sample = {
       "emotionConfidence": 0.88 // OPTIONAL: 0 = 0, 1.0 = 100%
     }],
 
-    // Entity reference (optional)
-    "entityId": "<GUID>",
-    "libraryId": "<GUID>",
-
     // Object (Face, Object, Logo, OCR, ..) (optional)
     "object": {
 


### PR DESCRIPTION
*This is a request to deprecate a portion of the vtn-standard spec.*

`object.entityId` and `object.libraryId` already exist, so they don't
make much sense to also be outside the object.

We know of no current uses of these keys outside of the object wrapper.