### PR TITLE
Docs Issue-222: Change HTTP to REST in Edge API headline

### DIFF
--- a/src/docs/_sidebar.md
+++ b/src/docs/_sidebar.md
@@ -46,7 +46,7 @@
       - [Paging](apis/tutorials/paging.md)
       - [Asset Types](apis/tutorials/asset-types.md)
 
-  - [Working with the Edge HTTP API](apis/edge/index.html)
+  - [Working with the Edge REST API](apis/edge/index.html)
 
 - [Tutorials](apis/tutorials/)
   - [GraphQL API Basics](apis/tutorials/graphql-basics.md)


### PR DESCRIPTION
This seems confusing and thought we might want to consider changing HTTP to REST since that is more accurate (eg both GraphQL and REST APIs use the HTTP protocol)