### PR TITLE
AIW-2352 - change to Edge REST API

### DIFF
--- a/src/docs/_sidebar.md
+++ b/src/docs/_sidebar.md
@@ -46,7 +46,7 @@
       - [Paging](apis/tutorials/paging.md)
       - [Asset Types](apis/tutorials/asset-types.md)
 
-  - [Working with the Edge HTTP API](apis/edge/index.html)
+  - [Working with the Edge REST API](apis/edge/index.html)
 
 - [Tutorials](apis/tutorials/)
   - [GraphQL API Basics](apis/tutorials/graphql-basics.md)


### PR DESCRIPTION
Clarifying that Edge is a REST API, as opposed to the lower-level "HTTP" (which GraphQL uses as well)