### PR TITLE
Feature/fix broken job links

### DIFF
--- a/src/docs/apis/job-quickstart/README.md
+++ b/src/docs/apis/job-quickstart/README.md
@@ -1,6 +1,6 @@
 # Job Quickstart Guide
 
-**NOTE: This Quickstart applies only to V2F (older aiWARE version) and is no longer current.** For the latest Quickstart, see [Working with Jobs](quickstart/jobs/).
+**NOTE: This Quickstart applies only to V2F (older aiWARE version) and is no longer current.** For the latest Quickstart, see [Working with Jobs](/quickstart/jobs/).
 
 ## Getting Started
 

--- a/src/docs/developer/engines/standards/engine-output/README.md
+++ b/src/docs/developer/engines/standards/engine-output/README.md
@@ -13,7 +13,7 @@ For specifications and examples for individual engine capabilities, please see t
 ## Full Specification
 
 The official specification is expressed in [json-schema](https://json-schema.org/) format according to various "validation contracts."
-The individual validation contracts are contained in their own schemas, which use definitions in the [master schema](/schemas/vtn-standard/master.json).
+The individual validation contracts are contained in their own schemas, which use definitions in the [master schema](/schemas/vtn-standard/master.json ':ignore').
 Engine output should express which validation contract(s) it conforms to by including the validation contract identifier in the validationContracts array at the top level of the output.
 
 > The [veritone-json-schemas npm package](https://www.npmjs.com/package/veritone-json-schemas) includes all the vtn-standard json-schemas and tools for validating against them.


### PR DESCRIPTION
I fixed the issue with the job quick start guide links detailed in this [issue](https://github.com/veritone/docs/issues/646).  

I updated the link to master.json in the vtn-standard schema docs, described in this [issue](https://github.com/veritone/docs/issues/645).  I was unable to locate the missing schema facial-features.json anywhere on GitHub, instead of removing the table entry I'm leaving it alone in hopes it will be fixed or updated.